### PR TITLE
Add GLib/AGS bindings for timers (timeout and interval)

### DIFF
--- a/src/AGS/Utils/Timeout.js
+++ b/src/AGS/Utils/Timeout.js
@@ -1,0 +1,6 @@
+export const intervalImpl =
+  (ms, callback, widget) =>
+    widget === undefined
+      ? Utils.interval(ms, callback)
+      : Utils.interval(ms, callback, widget)
+

--- a/src/AGS/Utils/Timeout.purs
+++ b/src/AGS/Utils/Timeout.purs
@@ -1,6 +1,7 @@
 module AGS.Utils.Timeout
   ( interval
   , timeout
+  , module GLib.Source
   ) where
 
 import Prelude
@@ -10,7 +11,7 @@ import Data.Time.Duration (Milliseconds)
 import Effect (Effect)
 import Effect.Uncurried (EffectFn3, runEffectFn3)
 import GLib.Priority (default)
-import GLib.Source (SourceID)
+import GLib.Source (SourceID, sourceRemove)
 import GLib.Timeout (timeoutAdd)
 import Gtk.Widget (Widget)
 import Untagged.Union (UndefinedOr, maybeToUor)

--- a/src/AGS/Utils/Timeout.purs
+++ b/src/AGS/Utils/Timeout.purs
@@ -1,0 +1,32 @@
+module AGS.Utils.Timeout
+  ( interval
+  , timeout
+  ) where
+
+import Prelude
+
+import Data.Maybe (Maybe)
+import Data.Time.Duration (Milliseconds)
+import Effect (Effect)
+import Effect.Uncurried (EffectFn3, runEffectFn3)
+import GLib.Priority (default)
+import GLib.Source (SourceID)
+import GLib.Timeout (timeoutAdd)
+import Gtk.Widget (Widget)
+import Untagged.Union (UndefinedOr, maybeToUor)
+
+-- TODO: reimplement in PureScript
+-- Currently the blocker is the lack of `widget.connect('destroy')`
+interval ∷ Milliseconds → Maybe Widget → Effect Unit → Effect SourceID
+interval ms widget ef = runEffectFn3 intervalImpl ms ef (maybeToUor widget)
+
+foreign import intervalImpl
+  ∷ EffectFn3
+      Milliseconds
+      (Effect Unit)
+      (UndefinedOr Widget)
+      SourceID
+
+timeout ∷ ∀ a. Milliseconds → Effect a → Effect SourceID
+timeout ms ef = timeoutAdd default ms (ef $> false)
+

--- a/src/GJS/Timer.js
+++ b/src/GJS/Timer.js
@@ -1,0 +1,3 @@
+export const setTimeoutImpl = setTimeout
+export const setIntervalImpl = setInterval
+

--- a/src/GJS/Timer.purs
+++ b/src/GJS/Timer.purs
@@ -1,0 +1,26 @@
+module GJS.Timer
+  ( setTimeout
+  , setInterval
+  , module GLib.Source
+  ) where
+
+import Prelude
+
+import Data.Time.Duration (Milliseconds)
+import Effect (Effect)
+import Effect.Uncurried (EffectFn2, runEffectFn2)
+import GLib.Source (GLibSource, destroy)
+
+-- | Execute an effect after a given number of milliseconds.
+-- | A timer set by this function can be cancelled using `GLib.Source.destroy`.
+setTimeout ∷ Milliseconds → Effect Unit → Effect GLibSource
+setTimeout = flip (runEffectFn2 setTimeoutImpl)
+
+-- | Execute an effect periodically with an interval of a given number of milliseconds.
+-- | A timer set by this function can be cancelled using `GLib.Source.destroy`.
+setInterval ∷ Milliseconds → Effect Unit → Effect GLibSource
+setInterval = flip (runEffectFn2 setIntervalImpl)
+
+foreign import setTimeoutImpl ∷ EffectFn2 (Effect Unit) Milliseconds GLibSource
+foreign import setIntervalImpl ∷ EffectFn2 (Effect Unit) Milliseconds GLibSource
+

--- a/src/GLib/Source.js
+++ b/src/GLib/Source.js
@@ -1,0 +1,10 @@
+import GLib from 'gi://GLib'
+
+export const destroy =
+  source => () =>
+    source.destroy()
+
+export const sourceRemove =
+  id => () =>
+    GLib.source_remove(id)
+

--- a/src/GLib/Source.purs
+++ b/src/GLib/Source.purs
@@ -1,0 +1,20 @@
+module GLib.Source
+  ( GLibSource
+  , SourceID
+  , destroy
+  , sourceRemove
+  ) where
+
+import Prelude
+
+import Effect (Effect)
+
+-- Some functions return GLib.Source, whereas some return a
+-- simple `number`. Still we'd like both to be typed.
+foreign import data GLibSource ∷ Type
+foreign import data SourceID ∷ Type
+
+foreign import destroy ∷ GLibSource → Effect Unit
+
+foreign import sourceRemove ∷ SourceID → Effect Unit
+

--- a/src/GLib/Timeout.js
+++ b/src/GLib/Timeout.js
@@ -1,0 +1,4 @@
+import GLib from 'gi://GLib'
+
+export const timeoutAddImpl = GLib.timeout_add
+

--- a/src/GLib/Timeout.purs
+++ b/src/GLib/Timeout.purs
@@ -1,0 +1,25 @@
+module GLib.Timeout (timeoutAdd) where
+
+import Data.Time.Duration (Milliseconds)
+import Effect (Effect)
+import Effect.Uncurried (EffectFn3, runEffectFn3)
+import GLib.Priority (Priority)
+import GLib.Source (SourceID)
+
+-- | Add a timer which will execute an effect as long as
+-- | this effect does not return `false`. The timer can be
+-- | manually cancelled with `GLib.Source.sourceRemove`.
+-- | https://gjs-docs.gnome.org/glib20~2.0/glib.timeout_add
+timeoutAdd ∷ Priority → Milliseconds → Effect Boolean → Effect SourceID
+timeoutAdd = runEffectFn3 timeoutAddImpl
+
+foreign import timeoutAddImpl
+  ∷ EffectFn3
+      Priority
+      Milliseconds
+      (Effect Boolean)
+      -- TODO should be newtyped, I don't know which
+      -- type GLib themselves reference though.
+      -- They just call it "number".
+      SourceID
+

--- a/src/GLib/Timeout.purs
+++ b/src/GLib/Timeout.purs
@@ -18,8 +18,5 @@ foreign import timeoutAddImpl
       Priority
       Milliseconds
       (Effect Boolean)
-      -- TODO should be newtyped, I don't know which
-      -- type GLib themselves reference though.
-      -- They just call it "number".
       SourceID
 

--- a/src/GLib/Timeout.purs
+++ b/src/GLib/Timeout.purs
@@ -1,10 +1,13 @@
-module GLib.Timeout (timeoutAdd) where
+module GLib.Timeout
+  ( timeoutAdd
+  , module GLib.Source
+  ) where
 
 import Data.Time.Duration (Milliseconds)
 import Effect (Effect)
 import Effect.Uncurried (EffectFn3, runEffectFn3)
 import GLib.Priority (Priority)
-import GLib.Source (SourceID)
+import GLib.Source (SourceID, sourceRemove)
 
 -- | Add a timer which will execute an effect as long as
 -- | this effect does not return `false`. The timer can be


### PR DESCRIPTION
Adds the following API:

- Modules `GLib.Source` and `GLib.Timeout` defining low-level bindings for timers (primarily, `add_timeout`.
- Module `GJS.Timers` for JS functions `setTimeout` and `setInterval`.
- Module `AGS.Utils.Timeout` to match AGS API.

There is a bit of overlap in their functionality, but it's not total, so I figured I just add all of them.