### PR TITLE
Add `Utils.lookupIcon`

### DIFF
--- a/src/AGS/Utils/Icon.js
+++ b/src/AGS/Utils/Icon.js
@@ -1,0 +1,2 @@
+export const lookupIconImpl = Utils.lookUpIcon
+

--- a/src/AGS/Utils/Icon.purs
+++ b/src/AGS/Utils/Icon.purs
@@ -1,0 +1,16 @@
+module AGS.Utils.Icon (lookupIcon) where
+
+import Prelude
+
+import Data.Maybe (Maybe)
+import Data.Nullable (Nullable, toMaybe)
+import Effect (Effect)
+import Effect.Uncurried (EffectFn2, runEffectFn2)
+import Gtk.IconInfo (GtkIconInfo)
+
+-- | Look up an icon given its name and size.
+lookupIcon ∷ String → Int → Effect (Maybe GtkIconInfo)
+lookupIcon name size = map toMaybe (runEffectFn2 lookupIconImpl name size)
+
+foreign import lookupIconImpl ∷ EffectFn2 String Int (Nullable GtkIconInfo)
+

--- a/src/Gtk/IconInfo.js
+++ b/src/Gtk/IconInfo.js
@@ -1,0 +1,4 @@
+export const getFilenameImpl =
+  iconInfo =>
+    iconInfo.get_filename()
+

--- a/src/Gtk/IconInfo.purs
+++ b/src/Gtk/IconInfo.purs
@@ -1,0 +1,4 @@
+module Gtk.IconInfo where
+
+foreign import data GtkIconInfo ∷ Type
+

--- a/src/Gtk/IconInfo.purs
+++ b/src/Gtk/IconInfo.purs
@@ -1,4 +1,14 @@
-module Gtk.IconInfo where
+module Gtk.IconInfo (GtkIconInfo, filename) where
+
+import Data.Maybe (Maybe)
+import Data.Nullable (Nullable, toMaybe)
+import Prelude ((<<<))
 
 foreign import data GtkIconInfo ∷ Type
+
+-- | Returns the full path to the icon, unless it's a builtin icon.
+filename ∷ GtkIconInfo → Maybe String
+filename = toMaybe <<< getFilenameImpl
+
+foreign import getFilenameImpl ∷ GtkIconInfo → Nullable String
 


### PR DESCRIPTION
I'll merge this when I figure out where `Gtk_IconInfo` is actually used.
